### PR TITLE
Fix energy array indexing for importActiveEnergyData/exportActiveEnergyData

### DIFF
--- a/custom_components/smappee_ev/coordinator.py
+++ b/custom_components/smappee_ev/coordinator.py
@@ -142,16 +142,39 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
 
         Returns:
         {
-            "grid": {"power":[...], "cons":[...]},
-            "pv":   {"power":[...], "cons":[...]},
-            "cars": { "<uuid>": {"power":[...], "cons":[...], "position": int|None, "serial": str|None } }
+            "grid": {"power":[...], "cons":[...], "energy":[...]},
+            "pv":   {"power":[...], "cons":[...], "energy":[...]},
+            "cars": { "<uuid>": {"power":[...], "cons":[...], "energy":[...], "position": int|None, "serial": str|None } }
         }
+
+        ``power`` indices are used for activePowerData/currentData (sparse,
+        indexed by physical CT input number).
+
+        ``energy`` indices are used for importActiveEnergyData/
+        exportActiveEnergyData which use a dense sequential layout
+        (rank among all configured consumptionIndex values).
         """
         mapping: dict[str, Any] = {
-            "grid": {"power": [], "cons": []},
-            "pv": {"power": [], "cons": []},
+            "grid": {"power": [], "cons": [], "energy": []},
+            "pv": {"power": [], "cons": [], "energy": []},
             "cars": {},
         }
+
+        # First pass: collect every consumptionIndex so we can rank them.
+        all_cons: list[int] = []
+        for meas in cfg.get("measurements") or []:
+            for ch in meas.get("channels") or []:
+                if "consumptionIndex" in ch:
+                    all_cons.append(int(ch["consumptionIndex"]))
+        for cs in cfg.get("chargingStations") or []:
+            for chg in cs.get("chargers") or []:
+                for ch in chg.get("channels") or []:
+                    if "consumptionIndex" in ch:
+                        all_cons.append(int(ch["consumptionIndex"]))
+
+        # Build rank lookup: consumptionIndex → 0-based position in sorted order.
+        sorted_cons = sorted(set(all_cons))
+        cons_to_rank = {ci: rank for rank, ci in enumerate(sorted_cons)}
 
         # measurements → GRID / PRODUCTION(PV)
         for meas in cfg.get("measurements") or []:
@@ -159,10 +182,13 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
             chans = meas.get("channels") or []
             pidx = [int(ch["powerTopicIndex"]) for ch in chans if "powerTopicIndex" in ch]
             cidx = [int(ch["consumptionIndex"]) for ch in chans if "consumptionIndex" in ch]
+            eidx = [cons_to_rank[ci] for ci in cidx if ci in cons_to_rank]
             if mtype == "GRID":
                 mapping["grid"]["power"], mapping["grid"]["cons"] = pidx, cidx
+                mapping["grid"]["energy"] = eidx
             elif mtype == "PRODUCTION":
                 mapping["pv"]["power"], mapping["pv"]["cons"] = pidx, cidx
+                mapping["pv"]["energy"] = eidx
 
         # chargingStations[].chargers[] → per-connector
         for cs in cfg.get("chargingStations") or []:
@@ -173,9 +199,11 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
                 chans = chg.get("channels") or []
                 pidx = [int(ch["powerTopicIndex"]) for ch in chans if "powerTopicIndex" in ch]
                 cidx = [int(ch["consumptionIndex"]) for ch in chans if "consumptionIndex" in ch]
+                eidx = [cons_to_rank[ci] for ci in cidx if ci in cons_to_rank]
                 mapping["cars"][uuid] = {
                     "power": pidx,
                     "cons": cidx,
+                    "energy": eidx,
                     "position": chg.get("position"),
                     "serial": chg.get("serialNumber"),
                 }
@@ -596,7 +624,7 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
         st,  # StationState
         payload: dict,
         power_idxs: list[int],
-        cons_idxs: list[int],
+        energy_idxs: list[int],
         power_key_prefix: str,  # "grid" or "pv"
     ) -> bool:
         changed = False
@@ -613,17 +641,17 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
             if i_ph:
                 changed |= self._set_if_changed(st, f"{power_key_prefix}_current_phases", i_ph)
 
-        if cons_idxs:
+        if energy_idxs:
             if power_key_prefix == "grid":
                 changed |= self._set_if_changed(
-                    st, "grid_energy_import_kwh", round(sum(_pick(imp_wh, cons_idxs)) / 1000.0, 3)
+                    st, "grid_energy_import_kwh", round(sum(_pick(imp_wh, energy_idxs)) / 1000.0, 3)
                 )
                 changed |= self._set_if_changed(
-                    st, "grid_energy_export_kwh", round(sum(_pick(exp_wh, cons_idxs)) / 1000.0, 3)
+                    st, "grid_energy_export_kwh", round(sum(_pick(exp_wh, energy_idxs)) / 1000.0, 3)
                 )
             else:  # pv
                 changed |= self._set_if_changed(
-                    st, "pv_energy_import_kwh", round(sum(_pick(imp_wh, cons_idxs)) / 1000.0, 3)
+                    st, "pv_energy_import_kwh", round(sum(_pick(imp_wh, energy_idxs)) / 1000.0, 3)
                 )
         return changed
 
@@ -632,7 +660,7 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
         conn,  # ConnectorState
         payload: dict,
         power_idxs: list[int],
-        cons_idxs: list[int],
+        energy_idxs: list[int],
     ) -> bool:
         changed = False
         active = payload.get("activePowerData") or []
@@ -641,8 +669,8 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
 
         p_ph = _pick(active, power_idxs)
         i_ma = _pick(currents_ma, power_idxs)
-        if cons_idxs:
-            energy_values = _pick(imp_wh, cons_idxs)
+        if energy_idxs:
+            energy_values = _pick(imp_wh, energy_idxs)
             if energy_values and len(set(energy_values)) == 1:
                 # All values are identical -> total energy replicated across indices
                 val = energy_values[0]
@@ -674,10 +702,10 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
 
         # Station groups
         changed |= self._apply_station_group(
-            st, payload, grid.get("power", []), grid.get("cons", []), "grid"
+            st, payload, grid.get("power", []), grid.get("energy", []), "grid"
         )
         changed |= self._apply_station_group(
-            st, payload, pv.get("power", []), pv.get("cons", []), "pv"
+            st, payload, pv.get("power", []), pv.get("energy", []), "pv"
         )
 
         # Connectors
@@ -686,7 +714,7 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
             if not conn:
                 continue
             changed |= self._apply_connector_values(
-                conn, payload, m.get("power", []), m.get("cons", [])
+                conn, payload, m.get("power", []), m.get("energy", [])
             )
 
         # Aggregate house consumption (positive load behind meter). Allow real zero.

--- a/custom_components/smappee_ev/coordinator.py
+++ b/custom_components/smappee_ev/coordinator.py
@@ -162,15 +162,19 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
 
         # First pass: collect every consumptionIndex so we can rank them.
         all_cons: list[int] = []
-        for meas in cfg.get("measurements") or []:
-            for ch in meas.get("channels") or []:
-                if "consumptionIndex" in ch:
-                    all_cons.append(int(ch["consumptionIndex"]))
-        for cs in cfg.get("chargingStations") or []:
-            for chg in cs.get("chargers") or []:
-                for ch in chg.get("channels") or []:
-                    if "consumptionIndex" in ch:
-                        all_cons.append(int(ch["consumptionIndex"]))
+        all_cons.extend(
+            int(ch["consumptionIndex"])
+            for meas in cfg.get("measurements") or []
+            for ch in meas.get("channels") or []
+            if "consumptionIndex" in ch
+        )
+        all_cons.extend(
+            int(ch["consumptionIndex"])
+            for cs in cfg.get("chargingStations") or []
+            for chg in cs.get("chargers") or []
+            for ch in chg.get("channels") or []
+            if "consumptionIndex" in ch
+        )
 
         # Build rank lookup: consumptionIndex → 0-based position in sorted order.
         sorted_cons = sorted(set(all_cons))


### PR DESCRIPTION
## Summary
- Fix grid energy import/export sensors showing 0 kWh
- Fix connector energy sensor showing grid energy instead of connector energy

## Problem

The MQTT `/power` topic payload uses **two different array indexing schemes**:

| Array | Indexing |
|---|---|
| `activePowerData`, `currentData` | Sparse — indexed by physical CT input number (matches `powerTopicIndex`) |
| `importActiveEnergyData`, `exportActiveEnergyData` | Dense — sequential rank among all configured measurement channels |

The integration currently uses `consumptionIndex` (= CT input number) for both power and energy arrays. This works for power data but produces wrong results for energy data when CT inputs don't start at 0.

### Example (real MQTT capture)

Setup: Smappee EV Wall Home + Connect, CTs at inputs 6-14.

`activePowerData` (sparse, 28 entries — `consumptionIndex` works):
```
[6]=1768W  [7]=1805W  [8]=1780W   <- charger (consumptionIndex 6,7,8)
[12]=1847W [13]=1977W [14]=1822W  <- grid    (consumptionIndex 12,13,14)
```

`importActiveEnergyData` (dense, data packed at 0-8 — `consumptionIndex` broken):
```
[0]=1881665  [1]=1591912  [2]=1563755   <- charger energy (rank 0,1,2)
[3]=4232486  [4]=4422739  [5]=4369044   <- solar energy   (rank 3,4,5)
[6]=5906935  [7]=6721551  [8]=4830838   <- grid energy    (rank 6,7,8)
[9..27] = 0
```

**Result:** Grid energy import picks indices 12,13,14 -> all zeros -> **reports 0 kWh**.
Connector energy picks indices 6,7,8 -> gets grid data -> **reports grid energy as connector energy**.

## Fix

Build a rank-based index mapping for energy arrays in `_build_power_index_map()`:
1. Collect all `consumptionIndex` values across measurements and charging stations
2. Sort and assign rank (0-based position in sorted order)
3. Use rank-based indices for `importActiveEnergyData`/`exportActiveEnergyData`
4. Continue using `powerTopicIndex` for `activePowerData`/`currentData` (unchanged)

## Test plan
- [x] Verify grid energy import/export sensors show correct non-zero cumulative values
- [x] Verify connector energy sensor shows connector-specific energy, not grid energy
- [x] Verify power sensors remain unaffected (they already work correctly)
- [ ] Verify setups where CTs start at index 0 are not affected (rank == consumptionIndex in that case)