### PR TITLE
Fix charging mode reverting to NORMAL after HA restart

### DIFF
--- a/custom_components/smappee_ev/coordinator.py
+++ b/custom_components/smappee_ev/coordinator.py
@@ -111,7 +111,7 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
                         session_state="Initialize",
                         selected_current_limit=None,
                         selected_percentage_limit=None,
-                        selected_mode="NORMAL",
+                        selected_mode=None,
                         min_current=DEFAULT_MIN_CURRENT,
                         max_current=DEFAULT_MAX_CURRENT,
                         min_surpluspct=DEFAULT_MIN_SURPLUS_PERCENT,
@@ -225,7 +225,7 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
         session_state = "Initialize"
         selected_percentage: int | None = None
         selected_current: int | None = None
-        selected_mode = "NORMAL"
+        selected_mode: str | None = None
         min_current = DEFAULT_MIN_CURRENT
         max_current = DEFAULT_MAX_CURRENT
         min_surpluspct = DEFAULT_MIN_SURPLUS_PERCENT

--- a/custom_components/smappee_ev/data.py
+++ b/custom_components/smappee_ev/data.py
@@ -19,7 +19,7 @@ class ConnectorState:
     session_state: str = "Initialize"
     selected_current_limit: int | None = None
     selected_percentage_limit: int | None = None
-    selected_mode: str = "NORMAL"
+    selected_mode: str | None = None
     min_current: int = DEFAULT_MIN_CURRENT
     max_current: int = DEFAULT_MAX_CURRENT
     min_surpluspct: int = DEFAULT_MIN_SURPLUS_PERCENT


### PR DESCRIPTION
## Summary
- Fix charging mode (e.g. SMART) reverting to NORMAL after a Home Assistant restart

## Problem

After a Home Assistant restart, the charging mode entity always shows NORMAL — even when SMART or SOLAR was previously active. The actual mode on the Smappee side is unaffected; only the reported mode in HA is wrong.

### Root cause

`chargingMode` and `optimizationStrategy` are **not available via the REST API** (the smartdevice `properties` only expose `chargingState` and `percentageLimit`). These fields are only pushed via MQTT.

On startup, `_fetch_connector_state()` hardcodes `selected_mode = "NORMAL"`. The `SmappeeModeSelect` entity uses `RestoreEntity` to persist the mode across restarts, but its restore check is:

```python
if st and st.selected_mode is None:
    st.selected_mode = restored
```

Because `selected_mode` is always `"NORMAL"` (never `None`) after `_fetch_connector_state()`, this check **always fails** and the restored mode (e.g. `"SMART"`) is silently discarded. The entity shows NORMAL until an MQTT `chargingstate` message happens to arrive.

### Why it worked when changing via dashboard

Changing the mode via the Smappee dashboard triggers an MQTT `chargingstate` message which updates HA correctly during normal operation. On restart however, no change occurs so no triggering MQTT message is sent, and the mode stays stuck at NORMAL.

## Fix

Change the default of `selected_mode` from `"NORMAL"` to `None` in both `data.py` and `_fetch_connector_state()`. This makes the existing `RestoreEntity` check `st.selected_mode is None` work as intended: the last known mode is restored from HA's persistent state immediately on startup, with MQTT confirming or correcting it moments later.

All existing usages of `selected_mode` already handle `None` safely (`select.py` uses `st.selected_mode or st.ui_mode_base or "NORMAL"`, `switch.py` and `button.py` use `getattr(..., None)`).

## Test plan
- [x] Set charging mode to SMART via Smappee dashboard
- [x] Restart Home Assistant
- [x] Verify charging mode entity shows SMART immediately after restart (not NORMAL)
- [x] Verify mode still updates correctly when changed via dashboard or HA during normal operation