### PR TITLE
Fix charging session timeout after ~5 minutes (#103)

### DIFF
--- a/custom_components/smappee_ev/api_client.py
+++ b/custom_components/smappee_ev/api_client.py
@@ -191,8 +191,11 @@ class SmappeeApiClient:
         """Start charging at (clamped) amperage.
 
         Returns (current_amps, percentage_limit) so caller can update ConnectorState.
+
+        Uses the chargingstations endpoint (NORMAL mode with AMPERE limit) instead of
+        the smartdevices/actions/startCharging action. The latter results in the cloud
+        suspending the session after ~5 minutes (EVSE -> SUSPENDED_EVSE), see issue #103.
         """
-        # _request handles auth
         if max_current < min_current:
             min_current, max_current = max_current, min_current
 
@@ -204,9 +207,7 @@ class SmappeeApiClient:
             rng = max_current - min_current
             percentage = int(max(0, min(100, round(((target - min_current) * 100.0) / rng))))
 
-        url = f"{BASE_URL}/servicelocation/{self.service_location_id}/smartdevices/{self.smart_device_uuid}/actions/startCharging"
-        payload = [{"spec": {"name": "percentageLimit", "species": "Integer"}, "value": percentage}]
-        await self._request("POST", url, json=payload, expected=(200,))
+        await self.set_charging_mode_chargingstations("NORMAL", limit=target, limit_unit="AMPERE")
 
         _LOGGER.debug(
             "Started charging successfully (target=%s A, pct=%s, range=%s-%s)",
@@ -218,8 +219,12 @@ class SmappeeApiClient:
         return target, percentage
 
     async def pause_charging(self) -> None:
-        url = f"{BASE_URL}/servicelocation/{self.service_location_id}/smartdevices/{self.smart_device_uuid}/actions/pauseCharging"
-        await self._request("POST", url, json=[], expected=(200,))
+        """Pause charging.
+
+        Uses the chargingstations endpoint (PAUSED mode) for consistency with
+        start_charging and to avoid the smartdevices/actions session timeout.
+        """
+        await self.set_charging_mode_chargingstations("PAUSED")
         _LOGGER.debug("Paused charging successfully")
 
     async def stop_charging(self) -> None:

--- a/custom_components/smappee_ev/switch.py
+++ b/custom_components/smappee_ev/switch.py
@@ -125,7 +125,7 @@ class SmappeeChargingSwitch(SmappeeConnectorEntity, SwitchEntity, RestoreEntity)
     # ---------- Actions ----------
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Start charging using selected or minimum current; set NORMAL mode first if needed."""
+        """Start charging using selected or minimum current."""
         st = self._conn_state()
         # Prefer selected current; else min_current; guard to >= 1
         if st:
@@ -134,22 +134,12 @@ class SmappeeChargingSwitch(SmappeeConnectorEntity, SwitchEntity, RestoreEntity)
                 if st.selected_current_limit is not None
                 else st.min_current
             )
-            mode = getattr(st, "selected_mode", None) or getattr(st, "ui_mode_base", None)
         else:
             current = 6
-            mode = "NORMAL"
 
         current = int(max(int(current or 6), 6))
 
         try:
-            if mode != "NORMAL":
-                _LOGGER.debug(
-                    "Charging switch: switching mode to NORMAL before starting (sid=%s, uuid=%s)",
-                    self._sid,
-                    self._uuid,
-                )
-                await self.api_client.set_charging_mode("NORMAL", current)
-
             _LOGGER.debug(
                 "Charging switch ON → start_charging %s A (sid=%s, uuid=%s)",
                 current,


### PR DESCRIPTION
The 'startCharging' and 'pauseCharging' smartdevices/actions endpoints cause the Smappee cloud to suspend the session after ~5 minutes (EVSE -> SUSPENDED_EVSE), regardless of charging mode, surplus percentage, or which HA entry point (button, EVCC switch, number entity) initiates the session.

Route start_charging and pause_charging through the chargingstations endpoint, mirroring set_charging_mode_chargingstations which the README already notes is 'more stable'. The session then runs continuously.

The public signature and return tuple of start_charging are preserved so the button/switch/number callers and ConnectorState bookkeeping are unchanged.

Also remove the now-redundant set_charging_mode('NORMAL', current) call in the EVCC charging switch's async_turn_on: start_charging itself now sets NORMAL via the chargingstations endpoint, so the preceding call to the old setChargingMode action is both unnecessary and a potential source of cloud-side race conditions.