### PR TITLE
feat: Add support for recent charging sessions and session energy sensor

### DIFF
--- a/custom_components/smappee_ev/__init__.py
+++ b/custom_components/smappee_ev/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import timedelta
 import logging
 from typing import cast
 
@@ -9,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 
 from .api_client import SmappeeApiClient
@@ -300,6 +302,14 @@ async def _create_coordinators(hass, stations, update_interval, config_entry=Non
         await coord.async_config_entry_first_refresh()
         bucket["coordinator"] = coord
 
+        hass.async_create_task(coord.async_background_refresh_recent_sessions())
+        session_timer_unsub = async_track_time_interval(
+            hass,
+            coord.async_background_refresh_recent_sessions,
+            timedelta(minutes=5),
+        )
+        if config_entry:
+            config_entry.async_on_unload(session_timer_unsub)
 
 def _setup_mqtt(
     hass, suuid, serial_str, sid, stations, client_id_prefix: str

--- a/custom_components/smappee_ev/__init__.py
+++ b/custom_components/smappee_ev/__init__.py
@@ -311,6 +311,7 @@ async def _create_coordinators(hass, stations, update_interval, config_entry=Non
         if config_entry:
             config_entry.async_on_unload(session_timer_unsub)
 
+
 def _setup_mqtt(
     hass, suuid, serial_str, sid, stations, client_id_prefix: str
 ) -> SmappeeMqtt | None:

--- a/custom_components/smappee_ev/api_client.py
+++ b/custom_components/smappee_ev/api_client.py
@@ -358,10 +358,11 @@ class SmappeeApiClient:
             return None
         return data if isinstance(data, dict) else None
 
-    async def get_recent_sessions(self) -> list | None:
+    async def get_recent_sessions(self) -> list[Any]:
         """Get recent charging sessions."""
         now_ms = int(time.time() * 1000)
         from_ms = now_ms - (7 * 24 * 60 * 60 * 1000)
 
         url = f"{BASE_URL}/chargingstations/{self.smart_device_uuid}/sessions?range={from_ms},{now_ms}"
-        return await self._request("GET", url, expected=(200,), return_json=True)
+        data = await self._request("GET", url, expected=(200,), return_json=True)
+        return data if isinstance(data, list) else []

--- a/custom_components/smappee_ev/api_client.py
+++ b/custom_components/smappee_ev/api_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import logging
+import time
 from typing import Any, Literal
 
 import aiohttp
@@ -356,3 +357,11 @@ class SmappeeApiClient:
             _LOGGER.warning("Metering configuration fetch failed: %s", exc)
             return None
         return data if isinstance(data, dict) else None
+
+    async def get_recent_sessions(self) -> list:
+        """Get recent charging sessions."""
+        now_ms = int(time.time() * 1000)
+        from_ms = now_ms - (7 * 24 * 60 * 60 * 1000)
+
+        url = f"{BASE_URL}/chargingstations/{self.smart_device_uuid}/sessions?range={from_ms},{now_ms}"
+        return await self._request("GET", url, expected=(200,), return_json=True)

--- a/custom_components/smappee_ev/api_client.py
+++ b/custom_components/smappee_ev/api_client.py
@@ -358,7 +358,7 @@ class SmappeeApiClient:
             return None
         return data if isinstance(data, dict) else None
 
-    async def get_recent_sessions(self) -> list:
+    async def get_recent_sessions(self) -> list | None:
         """Get recent charging sessions."""
         now_ms = int(time.time() * 1000)
         from_ms = now_ms - (7 * 24 * 60 * 60 * 1000)

--- a/custom_components/smappee_ev/coordinator.py
+++ b/custom_components/smappee_ev/coordinator.py
@@ -124,7 +124,9 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
 
             await self._ensure_power_index_map()
 
-            return IntegrationData(station=station_state, connectors=connectors_state, recent_sessions=recent_sessions)
+            return IntegrationData(
+                station=station_state, connectors=connectors_state, recent_sessions=recent_sessions
+            )
 
         except asyncio.CancelledError:
             raise
@@ -587,18 +589,14 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
             recent_sessions = await self.station_client.get_recent_sessions()
             if self.data:
                 self.data.recent_sessions = recent_sessions
-                # Update de entiteiten in Home Assistant
                 self.async_set_updated_data(self.data)
                 _LOGGER.debug("Recent sessions successfully refreshed.")
         except (TimeoutError, ClientError) as err:
-            # Dit zijn verwachte netwerk-fouten
             _LOGGER.warning("Network error while refreshing recent sessions: %s", err)
 
         except Exception as err:
-            # Vang alleen onverwachte fouten hier, maar log ze met stacktrace
             _LOGGER.exception("Unexpected error while refreshing recent sessions: %s", err)
-            # Optioneel: raise, als je wilt dat HA de integratie als 'failing' markeert
-            # raise
+
     # ---------- split sub-helpers ----------
     def _set_if_changed(self, obj: object, attr: str, value) -> bool:
         """Set attr if value is not None and different; return True if changed."""

--- a/custom_components/smappee_ev/coordinator.py
+++ b/custom_components/smappee_ev/coordinator.py
@@ -590,9 +590,15 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
                 # Update de entiteiten in Home Assistant
                 self.async_set_updated_data(self.data)
                 _LOGGER.debug("Recent sessions successfully refreshed.")
-        except Exception as sess_err:
-            _LOGGER.warning("Could not refresh recent sessions in background: %s", sess_err)
+        except (TimeoutError, ClientError) as err:
+            # Dit zijn verwachte netwerk-fouten
+            _LOGGER.warning("Network error while refreshing recent sessions: %s", err)
 
+        except Exception as err:
+            # Vang alleen onverwachte fouten hier, maar log ze met stacktrace
+            _LOGGER.exception("Unexpected error while refreshing recent sessions: %s", err)
+            # Optioneel: raise, als je wilt dat HA de integratie als 'failing' markeert
+            # raise
     # ---------- split sub-helpers ----------
     def _set_if_changed(self, obj: object, attr: str, value) -> bool:
         """Set attr if value is not None and different; return True if changed."""

--- a/custom_components/smappee_ev/coordinator.py
+++ b/custom_components/smappee_ev/coordinator.py
@@ -82,6 +82,7 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
         self.station_client = station_client
         self.connector_clients = connector_clients
         self._power_index_map: dict[str, Any] | None = None
+        self._last_session_api_update = 0.0
 
     async def _async_update_data(self) -> IntegrationData:
         try:
@@ -90,6 +91,9 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
 
             # ---- Station snapshot (LED brightness) ----
             station_state = await self._fetch_station_state(self.station_client)
+
+            # ---- Recent sessions ----
+            recent_sessions = self.data.recent_sessions if self.data else []
 
             # ---- Connectors in parallel ----
             pairs = list(self.connector_clients.items())  # [(uuid, client), ...]
@@ -120,7 +124,7 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
 
             await self._ensure_power_index_map()
 
-            return IntegrationData(station=station_state, connectors=connectors_state)
+            return IntegrationData(station=station_state, connectors=connectors_state, recent_sessions=recent_sessions)
 
         except asyncio.CancelledError:
             raise
@@ -551,14 +555,43 @@ class SmappeeCoordinator(DataUpdateCoordinator[IntegrationData]):
         return changed
 
     def _handle_connector_property_chargingstate(self, conn: ConnectorState, payload: dict) -> bool:
+        old_state = getattr(conn, "session_state", None)
+
         changed = False
         changed |= self._merge_cs_primary(conn, payload)
         changed |= self._merge_cs_context(conn, payload)
         changed |= self._merge_cs_modes(conn, payload)
         changed |= self._merge_cs_limits_availability(conn, payload)
-
         changed |= self._update_evcc(conn)
+
+        status_dict = payload.get("status") or {}
+        mqtt_state = status_dict.get("current") if isinstance(status_dict, dict) else None
+
+        if not mqtt_state:
+            mqtt_state = payload.get("chargingState")
+
+        if mqtt_state and old_state != mqtt_state:
+            _LOGGER.debug(
+                "Charging state changed from %s to %s (via MQTT). Triggering background session refresh.",
+                old_state,
+                mqtt_state,
+            )
+            self.hass.async_create_task(self.async_background_refresh_recent_sessions())
+
         return changed
+
+    async def async_background_refresh_recent_sessions(self, *_) -> None:
+        """Fetch recent sessions from the cloud API in the background."""
+        _LOGGER.critical("Refreshing recent sessions from Smappee API...")
+        try:
+            recent_sessions = await self.station_client.get_recent_sessions()
+            if self.data:
+                self.data.recent_sessions = recent_sessions
+                # Update de entiteiten in Home Assistant
+                self.async_set_updated_data(self.data)
+                _LOGGER.debug("Recent sessions successfully refreshed.")
+        except Exception as sess_err:
+            _LOGGER.warning("Could not refresh recent sessions in background: %s", sess_err)
 
     # ---------- split sub-helpers ----------
     def _set_if_changed(self, obj: object, attr: str, value) -> bool:

--- a/custom_components/smappee_ev/data.py
+++ b/custom_components/smappee_ev/data.py
@@ -83,6 +83,7 @@ class IntegrationData:
     connectors: dict[str, ConnectorState]  # keyed by UUID
     recent_sessions: list = field(default_factory=list)
 
+
 @dataclass
 class RuntimeData:
     """Runtime storage placed on ConfigEntry.runtime_data.

--- a/custom_components/smappee_ev/data.py
+++ b/custom_components/smappee_ev/data.py
@@ -1,7 +1,7 @@
 # custom_components/smappee_ev/data.py
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from homeassistant.config_entries import ConfigEntry
 
@@ -81,7 +81,7 @@ class IntegrationData:
 
     station: StationState
     connectors: dict[str, ConnectorState]  # keyed by UUID
-
+    recent_sessions: list = field(default_factory=list)
 
 @dataclass
 class RuntimeData:

--- a/custom_components/smappee_ev/sensor.py
+++ b/custom_components/smappee_ev/sensor.py
@@ -29,6 +29,7 @@ from .helpers import build_connector_label, safe_sum, update_total_increasing
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: SmappeeEvConfigEntry,
@@ -876,6 +877,7 @@ class SmappeeMqttLastSeenSensor(SmappeeStationEntity, SensorEntity):
             return datetime.fromtimestamp(float(ts), tz=UTC)
         except (TypeError, ValueError):
             return None
+
 
 class ConnectorSessionEnergySensor(SmappeeConnectorEntity, SensorEntity):
     """Sensor tracking total energy of the current/last session with all metadata in attributes."""

--- a/custom_components/smappee_ev/sensor.py
+++ b/custom_components/smappee_ev/sensor.py
@@ -919,15 +919,15 @@ class ConnectorSessionEnergySensor(SmappeeConnectorEntity, SensorEntity):
         if not session:
             return {}
 
-        # Create a shallow copy so we do not mutate the original coordinator data
+        # Create a shallow copy to prevent mutation of coordinator data
         attrs = dict(session)
 
-        # Remove the energy value since it is already exposed as the primary sensor state
+        # Remove primary state value
         attrs.pop("energy", None)
 
-        # Calculate and inject calculated duration details for convenience
+        # Calculate duration attributes
         start_ts = session.get("from")
-        if start_ts:
+        if start_ts is not None:
             try:
                 start_time = datetime.fromtimestamp(float(start_ts), tz=UTC)
                 end_ts = session.get("to")
@@ -940,7 +940,9 @@ class ConnectorSessionEnergySensor(SmappeeConnectorEntity, SensorEntity):
                 duration = end_time - start_time
                 attrs["duration_minutes"] = round(duration.total_seconds() / 60.0, 1)
 
+            except (ValueError, TypeError, OverflowError) as err:
+                _LOGGER.warning("Could not calculate session duration for %s: %s", start_ts, err)
             except Exception as err:
-                _LOGGER.error("Error calculating duration attribute for session: %s", err)
+                _LOGGER.exception("Unexpected error calculating session duration: %s", err)
 
         return attrs

--- a/custom_components/smappee_ev/sensor.py
+++ b/custom_components/smappee_ev/sensor.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import contextlib
 from datetime import UTC, datetime
+import logging
+from typing import Any
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -25,6 +27,7 @@ from .coordinator import SmappeeCoordinator
 from .data import SmappeeEvConfigEntry
 from .helpers import build_connector_label, safe_sum, update_total_increasing
 
+_LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -78,7 +81,7 @@ async def async_setup_entry(
                 entities.append(ConnCurrentL1(coord, client, sid, st_uuid, cuuid))
                 entities.append(ConnCurrentL2(coord, client, sid, st_uuid, cuuid))
                 entities.append(ConnCurrentL3(coord, client, sid, st_uuid, cuuid))
-
+                entities.append(ConnectorSessionEnergySensor(coord, client, sid, st_uuid, cuuid))
     async_add_entities(entities, True)
 
 
@@ -873,3 +876,71 @@ class SmappeeMqttLastSeenSensor(SmappeeStationEntity, SensorEntity):
             return datetime.fromtimestamp(float(ts), tz=UTC)
         except (TypeError, ValueError):
             return None
+
+class ConnectorSessionEnergySensor(SmappeeConnectorEntity, SensorEntity):
+    """Sensor tracking total energy of the current/last session with all metadata in attributes."""
+
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+
+    def __init__(
+        self, c: SmappeeCoordinator, api: SmappeeApiClient, sid: int, station_uuid: str, uuid: str
+    ) -> None:
+        """Initialize the unified session sensor."""
+        name = f"{build_connector_label(api, uuid)} Session energy"
+        super().__init__(
+            c, sid, station_uuid, uuid, unique_suffix="sensor:session_energy", name=name
+        )
+        self.api_client = api
+
+    @property
+    def _active_session_data(self) -> dict:
+        """Helper to safely extract the most recent v3 session (Index 0)."""
+        if not self.coordinator.data:
+            return {}
+        sessions = getattr(self.coordinator.data, "recent_sessions", [])
+        if sessions and isinstance(sessions, list) and len(sessions) > 0:
+            return sessions[0]
+        return {}
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the native value of the session energy in kWh."""
+        energy_kwh = self._active_session_data.get("energy")
+        if energy_kwh is None:
+            return 0.0
+        return round(float(energy_kwh), 2)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose all session metadata as attributes, excluding the state value itself."""
+        session = self._active_session_data
+        if not session:
+            return {}
+
+        # Create a shallow copy so we do not mutate the original coordinator data
+        attrs = dict(session)
+
+        # Remove the energy value since it is already exposed as the primary sensor state
+        attrs.pop("energy", None)
+
+        # Calculate and inject calculated duration details for convenience
+        start_ts = session.get("from")
+        if start_ts:
+            try:
+                start_time = datetime.fromtimestamp(float(start_ts), tz=UTC)
+                end_ts = session.get("to")
+
+                if end_ts and session.get("status") == "STOPPED":
+                    end_time = datetime.fromtimestamp(float(end_ts), tz=UTC)
+                else:
+                    end_time = datetime.now(UTC)
+
+                duration = end_time - start_time
+                attrs["duration_minutes"] = round(duration.total_seconds() / 60.0, 1)
+
+            except Exception as err:
+                _LOGGER.error("Error calculating duration attribute for session: %s", err)
+
+        return attrs


### PR DESCRIPTION
### Description

This PR introduces support for tracking and monitoring recent charging sessions from the Smappee v3 cloud API. It includes an optimized background update strategy to protect cloud API limits and tracks by nesting metadata directly inside state attributes.

### Key Changes

#### 1. Independent Core Refresh Strategy (`coordinator.py` & `__init__.py`)

* **Decoupled from main loop:** Removed historical charging session polling from the main `_async_update_data` loop to prevent API spamming or synchronization delays if the user sets a long polling interval.
* **Dual-Trigger Refresh Mechanics:**
1. **Time-Based:** Added an independent 5-minute recurring timer (`async_track_time_interval`) initiated during integration setup to periodically pull session data.
2. **Event-Based (Instant):** Connected MQTT `chargingstate` changes into a background worker (`async_background_refresh_recent_sessions`). When a vehicle changes state (e.g., transitions to `STARTED` or `CHARGING_FINISHED`), an immediate background fetch is executed to ensure frontend data reflects current reality instantly.
