### PR TITLE
feat: Add connector entities to connector device, linked to the charger device in HA

### DIFF
--- a/custom_components/smappee_ev/base_entities.py
+++ b/custom_components/smappee_ev/base_entities.py
@@ -22,7 +22,13 @@ class SmappeeBaseEntity(CoordinatorEntity[SmappeeCoordinator]):
 
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator: SmappeeCoordinator, sid: int, station_uuid: str, connector_label: str | None = None) -> None:
+    def __init__(
+        self,
+        coordinator: SmappeeCoordinator,
+        sid: int,
+        station_uuid: str,
+        connector_label: str | None = None,
+    ) -> None:
         super().__init__(coordinator)
         self._sid = sid
         self._station_uuid = station_uuid
@@ -31,7 +37,9 @@ class SmappeeBaseEntity(CoordinatorEntity[SmappeeCoordinator]):
 
     @property
     def device_info(self) -> DeviceInfo:
-        return make_device_info(self._sid, self._serial, self._station_uuid, connector_label=self._connector_label)
+        return make_device_info(
+            self._sid, self._serial, self._station_uuid, connector_label=self._connector_label
+        )
 
 
 class SmappeeStationEntity(SmappeeBaseEntity):

--- a/custom_components/smappee_ev/base_entities.py
+++ b/custom_components/smappee_ev/base_entities.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api_client import SmappeeApiClient
 from .coordinator import SmappeeCoordinator
-from .helpers import make_device_info, make_unique_id, station_serial, build_connector_id
+from .helpers import build_connector_id, make_device_info, make_unique_id, station_serial
 
 __all__ = [
     "SmappeeBaseEntity",

--- a/custom_components/smappee_ev/base_entities.py
+++ b/custom_components/smappee_ev/base_entities.py
@@ -5,8 +5,9 @@ from typing import Any
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .api_client import SmappeeApiClient
 from .coordinator import SmappeeCoordinator
-from .helpers import make_device_info, make_unique_id, station_serial
+from .helpers import make_device_info, make_unique_id, station_serial, build_connector_id
 
 __all__ = [
     "SmappeeBaseEntity",
@@ -21,15 +22,16 @@ class SmappeeBaseEntity(CoordinatorEntity[SmappeeCoordinator]):
 
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator: SmappeeCoordinator, sid: int, station_uuid: str) -> None:
+    def __init__(self, coordinator: SmappeeCoordinator, sid: int, station_uuid: str, connector_label: str | None = None) -> None:
         super().__init__(coordinator)
         self._sid = sid
         self._station_uuid = station_uuid
         self._serial = station_serial(coordinator)
+        self._connector_label = connector_label
 
     @property
     def device_info(self) -> DeviceInfo:
-        return make_device_info(self._sid, self._serial, self._station_uuid)
+        return make_device_info(self._sid, self._serial, self._station_uuid, connector_label=self._connector_label)
 
 
 class SmappeeStationEntity(SmappeeBaseEntity):
@@ -71,13 +73,15 @@ class SmappeeConnectorEntity(SmappeeBaseEntity):
     def __init__(
         self,
         coordinator: SmappeeCoordinator,
+        api: SmappeeApiClient,
         sid: int,
         station_uuid: str,
         connector_uuid: str,
         unique_suffix: str,
         name: str,
     ) -> None:
-        super().__init__(coordinator, sid, station_uuid)
+        connector_label = build_connector_id(api, connector_uuid)
+        super().__init__(coordinator, sid, station_uuid, connector_label=connector_label)
         self._connector_uuid = connector_uuid
         self._attr_unique_id = make_unique_id(
             sid, self._serial, station_uuid, connector_uuid, unique_suffix

--- a/custom_components/smappee_ev/button.py
+++ b/custom_components/smappee_ev/button.py
@@ -103,6 +103,7 @@ class SmappeeActionButton(SmappeeConnectorEntity, ButtonEntity):
         SmappeeConnectorEntity.__init__(
             self,
             coordinator,
+            api_client,
             sid,
             station_uuid,
             connector_uuid,

--- a/custom_components/smappee_ev/const.py
+++ b/custom_components/smappee_ev/const.py
@@ -32,9 +32,9 @@ MQTT_HEARTBEAT_TOPIC_SUFFIX: Final = "/homeassistant/heartbeat"
 
 # Config keys
 CONF_CLIENT_ID: str = "client_id"
-CONF_CLIENT_SECRET: str = "client_secret"  # noqa: S105 - config field name, not a secret
+CONF_CLIENT_SECRET: str = "client_secret"  # - config field name, not a secret
 CONF_USERNAME: str = "username"
-CONF_PASSWORD: str = "password"  # noqa: S105 - config field name, not a secret
+CONF_PASSWORD: str = "password"  # - config field name, not a secret
 CONF_SERVICE_LOCATION_ID: str = "service_location_id"
 CONF_SERVICE_LOCATION_UUID: str = "service_location_uuid"
 CONF_SMART_DEVICE_UUID: str = "smart_device_uuid"

--- a/custom_components/smappee_ev/const.py
+++ b/custom_components/smappee_ev/const.py
@@ -32,9 +32,9 @@ MQTT_HEARTBEAT_TOPIC_SUFFIX: Final = "/homeassistant/heartbeat"
 
 # Config keys
 CONF_CLIENT_ID: str = "client_id"
-CONF_CLIENT_SECRET: str = "client_secret"  # - config field name, not a secret
+CONF_CLIENT_SECRET: str = "client_secret"  # noqa: S105 - config field name, not a secret
 CONF_USERNAME: str = "username"
-CONF_PASSWORD: str = "password"  # - config field name, not a secret
+CONF_PASSWORD: str = "password"  # noqa: S105 - config field name, not a secret
 CONF_SERVICE_LOCATION_ID: str = "service_location_id"
 CONF_SERVICE_LOCATION_UUID: str = "service_location_uuid"
 CONF_SMART_DEVICE_UUID: str = "smart_device_uuid"

--- a/custom_components/smappee_ev/const.py
+++ b/custom_components/smappee_ev/const.py
@@ -1,6 +1,7 @@
 from typing import Final
 
 DOMAIN = "smappee_ev"
+MANUFACTURER = "Smappee"
 
 # Coordinator polling interval (seconds) – kept internal, no user option anymore
 UPDATE_INTERVAL_DEFAULT: Final = 30

--- a/custom_components/smappee_ev/helpers.py
+++ b/custom_components/smappee_ev/helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.helpers.entity import DeviceInfo
 
@@ -29,13 +29,16 @@ def make_device_info(
 
     # If a connector label is provided, treat it as a child device
     if connector_label:
-        device_info.update({
-            "identifiers": {(DOMAIN, f"{sid}:{serial}:{station_uuid}:{connector_label}")},
-            "name": f"Smappee EV {serial} | Connector {connector_label}",
-            "via_device": station_identifier,
-        })
+        device_info.update(
+            {
+                "identifiers": {(DOMAIN, f"{sid}:{serial}:{station_uuid}:{connector_label}")},
+                "name": f"Smappee EV {serial} | Connector {connector_label}",
+                "via_device": station_identifier,
+            }
+        )
 
-    return device_info
+    return cast(DeviceInfo, device_info)
+
 
 def make_unique_id(
     sid: int,
@@ -81,6 +84,7 @@ def build_connector_label(api_client, connector_uuid: str) -> str:
     """Return a human friendly connector label (prefers numeric connector number)."""
     num = getattr(api_client, "connector_number", None)
     return f"Connector {num}" if num is not None else f"Connector {connector_uuid[-4:]}"
+
 
 def build_connector_id(api_client, connector_uuid: str) -> str:
     """Return a human friendly connector label (prefers numeric connector number)."""

--- a/custom_components/smappee_ev/helpers.py
+++ b/custom_components/smappee_ev/helpers.py
@@ -6,21 +6,36 @@ from typing import Any
 
 from homeassistant.helpers.entity import DeviceInfo
 
-from .const import DOMAIN
+from .const import DOMAIN, MANUFACTURER
 
 
 def make_device_info(
     sid: int,
     serial: str,
     station_uuid: str,
+    connector_label: str | None = None,
 ) -> DeviceInfo:
-    """Return a Home Assistant device_info dict for a given station."""
-    return {
-        "identifiers": {(DOMAIN, f"{sid}:{serial}:{station_uuid}")},
+    """Return a Home Assistant device_info dict for a station or connector."""
+    
+    # The station is the main device (parent)
+    station_identifier = (DOMAIN, f"{sid}:{serial}:{station_uuid}")
+    
+    device_info = {
+        "identifiers": {station_identifier},
         "name": f"Smappee EV {serial}",
-        "manufacturer": "Smappee",
+        "manufacturer": MANUFACTURER,
+        "model": "EV Wall",
     }
 
+    # If a connector label is provided, treat it as a child device
+    if connector_label:
+        device_info.update({
+            "identifiers": {(DOMAIN, f"{sid}:{serial}:{station_uuid}:{connector_label}")},
+            "name": f"Smappee EV {serial} | Connector {connector_label}",
+            "via_device": station_identifier,
+        })
+
+    return device_info
 
 def make_unique_id(
     sid: int,
@@ -66,6 +81,11 @@ def build_connector_label(api_client, connector_uuid: str) -> str:
     """Return a human friendly connector label (prefers numeric connector number)."""
     num = getattr(api_client, "connector_number", None)
     return f"Connector {num}" if num is not None else f"Connector {connector_uuid[-4:]}"
+
+def build_connector_id(api_client, connector_uuid: str) -> str:
+    """Return a human friendly connector label (prefers numeric connector number)."""
+    num = getattr(api_client, "connector_number", None)
+    return str(num) if num is not None else str(connector_uuid[-4:])
 
 
 def update_total_increasing(last: float | None, candidate: float | None) -> float | None:

--- a/custom_components/smappee_ev/helpers.py
+++ b/custom_components/smappee_ev/helpers.py
@@ -16,10 +16,10 @@ def make_device_info(
     connector_label: str | None = None,
 ) -> DeviceInfo:
     """Return a Home Assistant device_info dict for a station or connector."""
-    
+
     # The station is the main device (parent)
     station_identifier = (DOMAIN, f"{sid}:{serial}:{station_uuid}")
-    
+
     device_info = {
         "identifiers": {station_identifier},
         "name": f"Smappee EV {serial}",

--- a/custom_components/smappee_ev/number.py
+++ b/custom_components/smappee_ev/number.py
@@ -99,6 +99,7 @@ class SmappeeCombinedCurrentSlider(SmappeeConnectorEntity, _BaseNumber):
         SmappeeConnectorEntity.__init__(
             self,
             coordinator,
+            api_client,
             sid,
             station_uuid,
             connector_uuid,
@@ -229,12 +230,14 @@ class SmappeeMinSurplusPctNumber(SmappeeConnectorEntity, _BaseNumber):
         SmappeeConnectorEntity.__init__(
             self,
             coordinator,
+            api_client,
             sid,
             station_uuid,
             connector_uuid,
             unique_suffix="number:min_surpluspct",
             name=f"Min Surplus Percentage {build_connector_label(api_client, connector_uuid).split(' ', 1)[1]}",
         )
+        _LOGGER.critical(getattr(coordinator, "station_client", None))
         self.api_client = api_client
         self._post_init(PERCENTAGE, 0, 100, 1)
 

--- a/custom_components/smappee_ev/number.py
+++ b/custom_components/smappee_ev/number.py
@@ -237,7 +237,6 @@ class SmappeeMinSurplusPctNumber(SmappeeConnectorEntity, _BaseNumber):
             unique_suffix="number:min_surpluspct",
             name=f"Min Surplus Percentage {build_connector_label(api_client, connector_uuid).split(' ', 1)[1]}",
         )
-        _LOGGER.critical(getattr(coordinator, "station_client", None))
         self.api_client = api_client
         self._post_init(PERCENTAGE, 0, 100, 1)
 

--- a/custom_components/smappee_ev/select.py
+++ b/custom_components/smappee_ev/select.py
@@ -63,6 +63,7 @@ class SmappeeModeSelect(SmappeeConnectorEntity, SelectEntity, RestoreEntity):
         SmappeeConnectorEntity.__init__(
             self,
             coordinator,
+            api_client,
             sid,
             station_uuid,
             connector_uuid,

--- a/custom_components/smappee_ev/sensor.py
+++ b/custom_components/smappee_ev/sensor.py
@@ -423,7 +423,14 @@ class ConnEnergyImport(RestoredEnergyConnectorSensor):
     ) -> None:
         name = f"{build_connector_label(api, uuid)} Energy import"
         SmappeeConnectorEntity.__init__(
-            self, c, api, sid, station_uuid, uuid, unique_suffix="sensor:energy_import_kwh", name=name
+            self,
+            c,
+            api,
+            sid,
+            station_uuid,
+            uuid,
+            unique_suffix="sensor:energy_import_kwh",
+            name=name,
         )
         self.api_client = api
 

--- a/custom_components/smappee_ev/sensor.py
+++ b/custom_components/smappee_ev/sensor.py
@@ -295,7 +295,7 @@ class ConnCurrentL1(SmappeeConnectorEntity, SensorEntity):
     ) -> None:
         name = f"{build_connector_label(api, uuid)} Current L1"
         SmappeeConnectorEntity.__init__(
-            self, c, sid, station_uuid, uuid, unique_suffix="sensor:current_l1", name=name
+            self, c, api, sid, station_uuid, uuid, unique_suffix="sensor:current_l1", name=name
         )
         self.api_client = api
 
@@ -316,7 +316,7 @@ class ConnCurrentL2(SmappeeConnectorEntity, SensorEntity):
     ) -> None:
         name = f"{build_connector_label(api, uuid)} Current L2"
         SmappeeConnectorEntity.__init__(
-            self, c, sid, station_uuid, uuid, unique_suffix="sensor:current_l2", name=name
+            self, c, api, sid, station_uuid, uuid, unique_suffix="sensor:current_l2", name=name
         )
         self.api_client = api
 
@@ -337,7 +337,7 @@ class ConnCurrentL3(SmappeeConnectorEntity, SensorEntity):
     ) -> None:
         name = f"{build_connector_label(api, uuid)} Current L3"
         SmappeeConnectorEntity.__init__(
-            self, c, sid, station_uuid, uuid, unique_suffix="sensor:current_l3", name=name
+            self, c, api, sid, station_uuid, uuid, unique_suffix="sensor:current_l3", name=name
         )
         self.api_client = api
 
@@ -358,7 +358,7 @@ class ConnectorPowerSensor(SmappeeConnectorEntity, SensorEntity):
     ) -> None:
         name = f"{build_connector_label(api, uuid)} Power"
         SmappeeConnectorEntity.__init__(
-            self, c, sid, station_uuid, uuid, unique_suffix="sensor:power_total", name=name
+            self, c, api, sid, station_uuid, uuid, unique_suffix="sensor:power_total", name=name
         )
         self.api_client = api
 
@@ -379,7 +379,7 @@ class ConnectorCurrentASensor(SmappeeConnectorEntity, SensorEntity):
     ) -> None:
         name = f"{build_connector_label(api, uuid)} Current"
         SmappeeConnectorEntity.__init__(
-            self, c, sid, station_uuid, uuid, unique_suffix="sensor:current_total", name=name
+            self, c, api, sid, station_uuid, uuid, unique_suffix="sensor:current_total", name=name
         )
         self.api_client = api
 
@@ -406,7 +406,7 @@ class SmappeeSupportGridSensor(SmappeeConnectorEntity, SensorEntity):
     ) -> None:
         name = f"{build_connector_label(api, uuid)} Support Grid"
         SmappeeConnectorEntity.__init__(
-            self, c, sid, station_uuid, uuid, unique_suffix="sensor:support_grid", name=name
+            self, c, api, sid, station_uuid, uuid, unique_suffix="sensor:support_grid", name=name
         )
         self.api_client = api
 
@@ -423,7 +423,7 @@ class ConnEnergyImport(RestoredEnergyConnectorSensor):
     ) -> None:
         name = f"{build_connector_label(api, uuid)} Energy import"
         SmappeeConnectorEntity.__init__(
-            self, c, sid, station_uuid, uuid, unique_suffix="sensor:energy_import_kwh", name=name
+            self, c, api, sid, station_uuid, uuid, unique_suffix="sensor:energy_import_kwh", name=name
         )
         self.api_client = api
 
@@ -728,7 +728,7 @@ class SmappeeChargingStateSensor(SmappeeConnectorEntity, SensorEntity):
     ) -> None:
         name = f"{build_connector_label(api, uuid)} Charging state"
         SmappeeConnectorEntity.__init__(
-            self, c, sid, station_uuid, uuid, unique_suffix="sensor:charging_state", name=name
+            self, c, api, sid, station_uuid, uuid, unique_suffix="sensor:charging_state", name=name
         )
         self.api_client = api
 
@@ -748,7 +748,7 @@ class SmappeeEVCCStateSensor(SmappeeConnectorEntity, RestoreSensor):
     ) -> None:
         name = f"{build_connector_label(api, uuid)} EVCC state"
         SmappeeConnectorEntity.__init__(
-            self, c, sid, station_uuid, uuid, unique_suffix="sensor:evcc_state", name=name
+            self, c, api, sid, station_uuid, uuid, unique_suffix="sensor:evcc_state", name=name
         )
         self.api_client = api
         self._restored_value: str | None = None
@@ -816,7 +816,7 @@ class SmappeeEvseStatusSensor(SmappeeConnectorEntity, RestoreSensor):
     ) -> None:
         name = f"{build_connector_label(api, uuid)} EVSE status"
         SmappeeConnectorEntity.__init__(
-            self, c, sid, station_uuid, uuid, unique_suffix="sensor:status_current", name=name
+            self, c, api, sid, station_uuid, uuid, unique_suffix="sensor:status_current", name=name
         )
         self.api_client = api
         self._restored_value: str | None = None
@@ -922,7 +922,7 @@ class ConnectorSessionEnergySensor(SmappeeConnectorEntity, SensorEntity):
     ) -> None:
         name = f"{build_connector_label(api, uuid)} Session energy"
         SmappeeConnectorEntity.__init__(
-            self, c, sid, station_uuid, uuid, unique_suffix="sensor:session_energy", name=name
+            self, c, api, sid, station_uuid, uuid, unique_suffix="sensor:session_energy", name=name
         )
         self.api_client = api
 

--- a/custom_components/smappee_ev/switch.py
+++ b/custom_components/smappee_ev/switch.py
@@ -90,6 +90,7 @@ class SmappeeChargingSwitch(SmappeeConnectorEntity, SwitchEntity, RestoreEntity)
         SmappeeConnectorEntity.__init__(
             self,
             coordinator,
+            api_client,
             sid,
             station_uuid,
             connector_uuid,


### PR DESCRIPTION
### Pull Request Description

#### Overview

This PR improves the device hierarchy for Smappee EV charging stations. Previously, all entities (station-level and connector-level) were associated directly with the main charging station device. This change introduces a proper hierarchy where connector-specific entities are now linked to their respective connector devices, which in turn are linked to the parent charging station device using `via_device`.

#### Changes

* **Refactored `make_device_info`:** Added an optional `connector_label` parameter. When provided, this function now returns a child device structure that uses `via_device` to point to the main station, allowing Home Assistant to group entities logically.
* **Updated `SmappeeBaseEntity` / `SmappeeConnectorEntity`:** Overrode the `device_info` property in connector-level entities to dynamically generate the correct hierarchical `DeviceInfo`.
* **Improved Entity Grouping:** Entities like `Max charging speed` and `Min Surplus Percentage` will now appear as part of their specific connector rather than cluttering the main station device.

#### Technical Details

* Introduced a hierarchical device relationship using the `via_device` property in `DeviceInfo`.
* Maintained backward compatibility with station-level entities (like LED brightness), which remain directly attached to the station device.
