### PR TITLE
fix: clear stale power/current readings when a charging session ends

### DIFF
--- a/custom_components/smappee_ev/coordinators/mqtt_apply.py
+++ b/custom_components/smappee_ev/coordinators/mqtt_apply.py
@@ -252,7 +252,21 @@ class MqttMixin(CoordinatorMixin):
         changed |= self._merge_cs_limits_availability(conn, payload)
 
         changed |= self._update_evcc(conn)
+
+        if was_active and not self._is_session_active(conn):
+            changed |= self._clear_connector_power(conn)
+
         self._handle_session_tracking_transition(conn, was_active, connector_uuid)
+        return changed
+
+    @staticmethod
+    def _clear_connector_power(conn: ConnectorState) -> bool:
+        """Clear stale power/current readings when a charging session ends."""
+        changed = False
+        for attr, zero in (("power_total", 0), ("power_phases", None), ("current_phases", None)):
+            if getattr(conn, attr) not in (zero, None):
+                setattr(conn, attr, zero)
+                changed = True
         return changed
 
     def _merge_cs_primary(self, conn: ConnectorState, payload: dict) -> bool:


### PR DESCRIPTION
Fixes #270 

## Fix stale connector power reading when vehicle stops charging session

When a charging session is stopped from the vehicle, Smappee publishes a `chargingstate` MQTT message transitioning the connector to `available`, but does not publish a final `0 W` power message. This left `power_total` and related fields on the connector frozen at the last measured value (e.g. ~8 kW) until the next MQTT power update or integration restart.

## Root cause

Connector power values (`power_total`, `power_phases`, `current_phases`) are only updated by the `/power` topic handler. When the vehicle initiates the stop, the `chargingstate` topic fires correctly but no corresponding power update follows, so the stale readings persist.

## Fix

In `_handle_connector_property_chargingstate`, detect the `active → inactive` session transition after all state merges are applied and immediately clear the stale power readings:
- `power_total` → `0` (correct physical value for a stopped session)
- `power_phases` / `current_phases` → `None`

## Scenarios

| Scenario | Before | After |
|---|---|---|
| Start + stop via RFID | ✅ 0 W | ✅ 0 W |
| Start via RFID, stop from vehicle | ❌ stale ~8 kW | ✅ 0 W |
| Session ends on full battery | ✅ 0 W | ✅ 0 W |

Scenarios 1 and 3 are unaffected — the `was_active → not active` guard only fires on a genuine session-end transition, and those scenarios already produced correct readings via a final power MQTT message.
