### PR TITLE
fix: handle session state initialization in station state merging

### DIFF
--- a/custom_components/smappee_ev/coordinators/api_state.py
+++ b/custom_components/smappee_ev/coordinators/api_state.py
@@ -89,7 +89,9 @@ class StationApiMixin(CoordinatorMixin):
         return replace(
             prev,
             connector_number=rest.connector_number,
-            session_state=rest.session_state,
+            session_state=rest.session_state
+            if rest.session_state != "Initialize"
+            else prev.session_state,
             selected_current_limit=rest.selected_current_limit
             if rest.selected_current_limit is not None
             else prev.selected_current_limit,


### PR DESCRIPTION
Fixes #271 

## Fix charging_state sensor showing stale or incorrect value after session end

The `charging_state` sensor could show `initialize` shortly after a session ended, even though the correct `STOPPED` state had already arrived via MQTT.

## Root cause

`_merge_connector_rest_state` unconditionally overwrote `session_state` with the REST value on every coordinator refresh. When the REST API returns no `chargingState` property, `_fetch_connector_state` falls back to the hardcoded default `"Initialize"`, which then silently clobbered the MQTT-sourced `"STOPPED"` state.

## Fix

In `_merge_connector_rest_state`, only apply the REST `session_state` when it carries a real value (i.e. not the default `"Initialize"`). If the REST response has no meaningful state, the existing MQTT-sourced value is preserved.

```python
session_state=rest.session_state if rest.session_state != "Initialize" else prev.session_state,
```

## Behaviour

| Situation | Before | After |
|---|---|---|
| REST returns `"STOPPED"` | ✅ correct | ✅ correct |
| REST returns `"CHARGING"` | ✅ correct | ✅ correct |
| REST returns no `chargingState` (default `"Initialize"`) | ❌ overwrites MQTT value | ✅ MQTT value preserved |
