### PR TITLE
feat: add module offline warning blueprint and update blueprints documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,63 +139,11 @@ This is the current version of the entities (for my EV Wall Home single connecto
 
 ## 📐 Automation Blueprints
 
-### Smappee: Forgot to Scan RFID Badge
+See the [Blueprints documentation](./docs/blueprints.md) for the full list of available blueprints, including:
 
-Sends a push notification to your phone when your EV has been plugged into the Smappee charger for a configurable amount of time without starting a charging session — a reminder to scan your RFID badge.
-
-#### What it does
-
-- **Monitors charger status:** Watches for the `cable_connected` state on your Smappee EVSE sensor.
-- **Configurable delay:** Waits a set amount of time (default: 5 minutes) before alerting, to allow for normal badge scanning.
-- **Mobile notification:** Sends a push notification to your phone via the Home Assistant Companion app.
-
-#### Easy Import
-
-Click the button below to import this blueprint into your Home Assistant instance:
-
-[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint URL pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fmyny-git%2Fsmappee_ev%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fforgot_to_scan_rfid_badge.yaml)
-
-#### Manual Setup
-
-1. Download `blueprints/automation/forgot_to_scan_rfid_badge.yaml`.
-2. Place it in your Home Assistant config directory:
-
-   ```bash
-   config/blueprints/automation/forgot_to_scan_rfid_badge.yaml
-
-   ```
-
-3. Go to **Settings → Automations & Scenes → Blueprints**, click **Reload Blueprints**, then **Create Automation**.
-
----
-
-### Smappee: Charger status and sun-based LED brightness
-
-Adjusts the Smappee charger LED brightness based on charger availability (2% when available) and sun state with configurable offsets.
-
-#### Features
-
-- **Charger-aware:** Sets LED to 2% brightness when the charger status is "available".
-- **Sun-triggered fallback:** When not available, adjusts brightness based on sunrise and sunset.
-- **Configurable offsets:** Shift the trigger time before or after sunrise/sunset (e.g. `-00:30:00` to trigger 30 minutes early).
-- **Configurable brightness:** Set independent brightness percentages for daytime and nighttime.
-
-#### Import
-
-Click the button below to import this blueprint into your Home Assistant instance:
-
-[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint URL pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fmyny-git%2Fsmappee_ev%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fsun_charger_state_led.yaml)
-
-#### Setup
-
-1. Download `blueprints/automation/sun_charger_state_led.yaml`.
-2. Place it in your Home Assistant config directory:
-
-   ```bash
-   config/blueprints/automation/sun_charger_state_led.yaml
-   ```
-
-3. Go to **Settings → Automations & Scenes → Blueprints**, click **Reload Blueprints**, then **Create Automation**.
+- **Forgot to Scan RFID Badge** – notifies you when a car is connected but no session has started.
+- **Charger Status and Sun-Based LED Brightness** – adjusts LED brightness based on charger state and sun position.
+- **Module Offline Warning** – alerts you when a Smappee sensor goes unavailable.
 
 ## 💡 Notes
 

--- a/blueprints/automation/module_offline_warning.yaml
+++ b/blueprints/automation/module_offline_warning.yaml
@@ -1,0 +1,71 @@
+blueprint:
+  name: 'Smappee: Module Offline Warning'
+  description: Send a notification when a Smappee sensor goes offline, indicating a probable loss of connection.
+  domain: automation
+  input:
+    smappee_sensor:
+      name: Smappee Sensor
+      description: The Smappee sensor to monitor (e.g., house consumption or P1 power sensor).
+      selector:
+        entity:
+          filter:
+          - domain:
+            - sensor
+            integration: smappee_ev
+          multiple: false
+    offline_delay:
+      name: Delay Time
+      description: How long the sensor must remain unavailable before sending the notification.
+      default: 5
+      selector:
+        number:
+          min: 1.0
+          max: 60.0
+          unit_of_measurement: minutes
+          mode: slider
+          step: 1.0
+    notify_service:
+      name: Notification Target
+      description: Select the device or group that should receive the alert.
+      selector:
+        target:
+          entity:
+            domain: notify
+    notification_title:
+      name: Notification Title
+      description: The title header text of the push notification message.
+      default: '⚠️ Smappee: Connection Lost'
+      selector:
+        text:
+          multiple: false
+          multiline: false
+    notification_message:
+      name: Notification Message
+      description: The body text of the message. Use {{ delay_minutes }} to inject the dynamic countdown value.
+      default: The Smappee module has been unreachable for {{ delay_minutes }} minutes. Please check the P1 module and your network connection.
+      selector:
+        text:
+          multiple: false
+          multiline: false
+
+variables:
+  delay_minutes: !input offline_delay
+  notification_message: !input notification_message
+
+trigger:
+  - platform: state
+    entity_id: !input smappee_sensor
+    to:
+      - unavailable
+      - unknown
+    for:
+      minutes: !input offline_delay
+
+action:
+  - action: notify.send_message
+    target: !input notify_service
+    data:
+      title: !input notification_title
+      message: '{{ notification_message }}'
+
+mode: single

--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -1,0 +1,81 @@
+# 📐 Automation Blueprints
+
+## Smappee: Forgot to Scan RFID Badge
+
+Sends a push notification to your phone when your EV has been plugged into the Smappee charger for a configurable amount of time without starting a charging session — a reminder to scan your RFID badge.
+
+### What it does
+
+- **Monitors charger status:** Watches for the `cable_connected` state on your Smappee EVSE sensor.
+- **Configurable delay:** Waits a set amount of time (default: 5 minutes) before alerting, to allow for normal badge scanning.
+- **Mobile notification:** Sends a push notification to your phone via the Home Assistant Companion app.
+
+### Easy Import
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint URL pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fmyny-git%2Fsmappee_ev%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fforgot_to_scan_rfid_badge.yaml)
+
+### Manual Setup
+
+1. Download `blueprints/automation/forgot_to_scan_rfid_badge.yaml`.
+2. Place it in your Home Assistant config directory:
+
+   ```bash
+   config/blueprints/automation/forgot_to_scan_rfid_badge.yaml
+   ```
+
+3. Go to **Settings → Automations & Scenes → Blueprints**, click **Reload Blueprints**, then **Create Automation**.
+
+---
+
+## Smappee: Charger Status and Sun-Based LED Brightness
+
+Adjusts the Smappee charger LED brightness based on charger availability (2% when available) and sun state with configurable offsets.
+
+### Features
+
+- **Charger-aware:** Sets LED to 2% brightness when the charger status is "available".
+- **Sun-triggered fallback:** When not available, adjusts brightness based on sunrise and sunset.
+- **Configurable offsets:** Shift the trigger time before or after sunrise/sunset (e.g. `-00:30:00` to trigger 30 minutes early).
+- **Configurable brightness:** Set independent brightness percentages for daytime and nighttime.
+
+### Import
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint URL pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fmyny-git%2Fsmappee_ev%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fsun_charger_state_led.yaml)
+
+### Setup
+
+1. Download `blueprints/automation/sun_charger_state_led.yaml`.
+2. Place it in your Home Assistant config directory:
+
+   ```bash
+   config/blueprints/automation/sun_charger_state_led.yaml
+   ```
+
+3. Go to **Settings → Automations & Scenes → Blueprints**, click **Reload Blueprints**, then **Create Automation**.
+
+---
+
+## Smappee: Module Offline Warning
+
+Sends a notification when a Smappee sensor goes offline, indicating a probable loss of connection (e.g. P1 module or network issue).
+
+### What it does
+
+- **Monitors sensor availability:** Watches any Smappee integration sensor for an `unavailable` or `unknown` state.
+- **Configurable delay:** Waits a set amount of time (default: 5 minutes) before alerting, to avoid false positives from brief dropouts.
+- **Mobile notification:** Sends a push notification with a customisable title and message. Use `{{ delay_minutes }}` in the message body to include the configured delay dynamically.
+
+### Import
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint URL pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fmyny-git%2Fsmappee_ev%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fmodule_offline_warning.yaml)
+
+### Manual Setup
+
+1. Download `blueprints/automation/module_offline_warning.yaml`.
+2. Place it in your Home Assistant config directory:
+
+   ```bash
+   config/blueprints/automation/module_offline_warning.yaml
+   ```
+
+3. Go to **Settings → Automations & Scenes → Blueprints**, click **Reload Blueprints**, then **Create Automation**.


### PR DESCRIPTION
### What

- Added a new automation blueprint: **Smappee: Module Offline Warning** (`blueprints/automation/module_offline_warning.yaml`). It triggers a notification when any Smappee sensor stays `unavailable` or `unknown` for a configurable delay, useful for detecting P1 module or network connectivity issues.
- Extracted the full blueprints documentation from `README.md` into a dedicated `docs/blueprints.md`, consistent with how EVCC, openEMS and emhass docs are handled.
- Replaced the verbose blueprints section in `README.md` with a short summary and a link to `docs/blueprints.md`.

### Why

The README blueprints section was growing with each new blueprint. Moving it to a dedicated doc keeps the README concise and makes it easier to maintain blueprint documentation independently.

### Changes

| File | Change |
|---|---|
| `README.md` | Replaced full blueprints section with a short summary + link |
| `docs/blueprints.md` | New file — full documentation for all 3 blueprints |
| `blueprints/automation/module_offline_warning.yaml` | New blueprint — module offline warning |
