### PR TITLE
fix: start charging at the configured current instead of the connector maximum

### DIFF
--- a/custom_components/smappee_ev/api/dashboard_client.py
+++ b/custom_components/smappee_ev/api/dashboard_client.py
@@ -416,10 +416,10 @@ class SmappeeDashboardClient:
             )
         )
 
-    async def async_set_percentage_limit(
-        self, service_location_id: int | str, device_id: str, percentage: int
-    ) -> bool:
-        payload = [
+    @staticmethod
+    def _percentage_limit_payload(percentage: int) -> DashboardObjectList:
+        """Build the shared ``percentageLimit`` action payload."""
+        return [
             {
                 "spec": {
                     "name": "percentageLimit",
@@ -430,8 +430,15 @@ class SmappeeDashboardClient:
                 "values": [{"Integer": int(percentage)}],
             }
         ]
+
+    async def async_set_percentage_limit(
+        self, service_location_id: int | str, device_id: str, percentage: int
+    ) -> bool:
         return await self.async_execute_device_action(
-            service_location_id, device_id, "setPercentageLimit", payload
+            service_location_id,
+            device_id,
+            "setPercentageLimit",
+            self._percentage_limit_payload(percentage),
         )
 
     async def async_set_led_brightness(
@@ -464,20 +471,14 @@ class SmappeeDashboardClient:
             {"Quantity": {"value": int(max_current_a), "unit": "A"}},
         )
 
-    async def async_start_charging(self, service_location_id: int | str, device_id: str) -> bool:
-        payload = [
-            {
-                "spec": {
-                    "name": "percentageLimit",
-                    "species": "Integer",
-                    "unit": "%",
-                    "required": True,
-                },
-                "values": [{"Integer": 100}],
-            }
-        ]
+    async def async_start_charging(
+        self, service_location_id: int | str, device_id: str, percentage: int = 100
+    ) -> bool:
         return await self.async_execute_device_action(
-            service_location_id, device_id, "startCharging", payload
+            service_location_id,
+            device_id,
+            "startCharging",
+            self._percentage_limit_payload(percentage),
         )
 
     async def async_pause_charging(self, service_location_id: int | str, device_id: str) -> bool:

--- a/custom_components/smappee_ev/api/device_handle.py
+++ b/custom_components/smappee_ev/api/device_handle.py
@@ -211,16 +211,19 @@ class SmappeeDeviceHandle:
         _LOGGER.debug("Charging mode set successfully (%s via Dashboard v10)", mode_up)
         return True
 
-    async def start_charging(self) -> None:
+    async def start_charging(self, percentage: int | None = None) -> None:
         """Start charging via Dashboard v10.
 
         This matches the Smappee app Start button:
-        startcharging = {"percentageLimit": 100}.
+        startcharging = {"percentageLimit": <limit>}.
 
-        Use set_current to adjust the current/percentage limit.
+        ``percentageLimit`` is the same device field the current slider writes,
+        so callers pass the connector's active setpoint to keep it. Without a
+        known setpoint we fall back to 100%.
         """
-        await self._require_dashboard_action("async_start_charging")
-        _LOGGER.debug("Started charging successfully via Dashboard v10")
+        pct = 100 if percentage is None else max(0, min(100, int(percentage)))
+        await self._require_dashboard_action("async_start_charging", pct)
+        _LOGGER.debug("Started charging successfully at %d%% via Dashboard v10", pct)
 
     async def pause_charging(self) -> None:
         """Pause charging via Dashboard v10.

--- a/custom_components/smappee_ev/button.py
+++ b/custom_components/smappee_ev/button.py
@@ -14,7 +14,7 @@ from .api.errors import SmappeeError
 from .const import DOMAIN
 from .coordinator import SmappeeCoordinator
 from .entity import SmappeeConnectorEntity, SmappeeStationEntity
-from .helpers import dashboard_mode, station_action_error
+from .helpers import connector_percentage_setpoint, dashboard_mode, station_action_error
 from .models.runtime_data import SmappeeEvConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -175,8 +175,10 @@ class SmappeeActionButton(SmappeeConnectorEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Execute the action on press."""
         if self._action == "start_charging":
+            data = self.coordinator.data if self.coordinator else None
+            conn = (data.connectors or {}).get(self.connector_uuid) if data else None
             try:
-                await self.api_client.start_charging()
+                await self.api_client.start_charging(connector_percentage_setpoint(conn))
             except (SmappeeError, ClientError, TimeoutError, RuntimeError, ValueError) as err:
                 raise _connector_action_error("start_charging", err) from err
             self.coordinator.async_schedule_dashboard_refresh()

--- a/custom_components/smappee_ev/coordinators/api_state.py
+++ b/custom_components/smappee_ev/coordinators/api_state.py
@@ -13,7 +13,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from ..api.device_handle import SmappeeDeviceHandle
 from ..api.errors import SmappeeError
 from ..const import DEFAULT_MAX_CURRENT, DEFAULT_MIN_CURRENT
-from ..helpers import anonymize_uuid, dashboard_property_value
+from ..helpers import anonymize_uuid, dashboard_property_value, percentage_to_current
 from ..models.state import ConnectorState, StationState
 from .base import CoordinatorMixin
 from .power import _to_int
@@ -80,6 +80,23 @@ class StationApiMixin(CoordinatorMixin):
         )
 
     @staticmethod
+    def _rest_selected_current_limit(prev: ConnectorState, rest: ConnectorState) -> float | None:
+        """Derive the Ampere setpoint from the polled percentage limit.
+
+        REST only exposes ``percentageLimit``, so without this a stale
+        MQTT-derived ``selected_current_limit`` could never be corrected by a
+        poll. Mirrors the MQTT gate: the percentage only drives the setpoint
+        while the connector runs without an optimization strategy.
+        """
+        if (prev.optimization_strategy or "").upper() != "NONE":
+            return prev.selected_current_limit
+        if rest.selected_percentage_limit is None:
+            return prev.selected_current_limit
+        return percentage_to_current(
+            rest.selected_percentage_limit, rest.min_current, rest.max_current
+        )
+
+    @staticmethod
     def _merge_connector_rest_state(
         prev: ConnectorState | None, rest: ConnectorState
     ) -> ConnectorState:
@@ -92,9 +109,7 @@ class StationApiMixin(CoordinatorMixin):
             session_state=rest.session_state
             if rest.session_state != "Initialize"
             else prev.session_state,
-            selected_current_limit=rest.selected_current_limit
-            if rest.selected_current_limit is not None
-            else prev.selected_current_limit,
+            selected_current_limit=StationApiMixin._rest_selected_current_limit(prev, rest),
             selected_percentage_limit=rest.selected_percentage_limit,
             selected_mode=rest.selected_mode
             if rest.selected_mode is not None
@@ -148,7 +163,6 @@ class StationApiMixin(CoordinatorMixin):
         """Read one connector's properties/config from its smartdevice."""
         session_state = "Initialize"
         selected_percentage: int | None = None
-        selected_current: int | None = None
         selected_mode: str | None = None
         min_current = DEFAULT_MIN_CURRENT
         max_current = DEFAULT_MAX_CURRENT
@@ -190,7 +204,7 @@ class StationApiMixin(CoordinatorMixin):
         return ConnectorState(
             connector_number=getattr(client, "connector_number", 1),
             session_state=session_state,
-            selected_current_limit=selected_current,
+            selected_current_limit=None,
             selected_percentage_limit=selected_percentage,
             selected_mode=selected_mode,
             min_current=min_current,

--- a/custom_components/smappee_ev/helpers.py
+++ b/custom_components/smappee_ev/helpers.py
@@ -9,7 +9,7 @@ from typing import Any
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 
-from .const import CONFIGURATION_URL, DOMAIN, MANUFACTURER
+from .const import CONFIGURATION_URL, DEFAULT_MAX_CURRENT, DEFAULT_MIN_CURRENT, DOMAIN, MANUFACTURER
 
 
 def dashboard_property_value(prop: object) -> Any:
@@ -244,6 +244,40 @@ def connector_state(coordinator: Any, connector_uuid: str) -> Any | None:
     if not data:
         return None
     return (getattr(data, "connectors", None) or {}).get(connector_uuid)
+
+
+def percentage_to_current(percentage: int, min_current: int, max_current: int) -> float:
+    """Convert a Dashboard ``percentageLimit`` to Ampere within the connector range."""
+    rng = max(int(max_current) - int(min_current), 1)
+    return round((int(percentage) / 100.0) * rng + float(min_current), 1)
+
+
+def current_to_percentage(current: float, min_current: int, max_current: int) -> int:
+    """Convert Ampere to the nearest Dashboard ``percentageLimit`` in 0-100."""
+    rng = max(int(max_current) - int(min_current), 1)
+    pct = int(round((float(current) - float(min_current)) * 100.0 / rng))
+    return max(0, min(100, pct))
+
+
+def connector_percentage_setpoint(state: Any) -> int | None:
+    """Return the connector's charging setpoint as a Dashboard percentage.
+
+    Prefers the percentage the API reported and falls back to deriving it from
+    the Ampere setpoint. Returns ``None`` when neither representation is known.
+    """
+    if state is None:
+        return None
+    pct = getattr(state, "selected_percentage_limit", None)
+    if pct is not None:
+        return max(0, min(100, int(pct)))
+    current = getattr(state, "selected_current_limit", None)
+    if current is None:
+        return None
+    return current_to_percentage(
+        current,
+        getattr(state, "min_current", DEFAULT_MIN_CURRENT),
+        getattr(state, "max_current", DEFAULT_MAX_CURRENT),
+    )
 
 
 def build_connector_label(api_client: Any, connector_uuid: str) -> str:

--- a/custom_components/smappee_ev/services.py
+++ b/custom_components/smappee_ev/services.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from .api.device_handle import SmappeeDeviceHandle
 from .const import CHARGING_MODES, DEFAULT_MAX_CURRENT, DEFAULT_MIN_CURRENT, DOMAIN
-from .helpers import dashboard_mode
+from .helpers import connector_percentage_setpoint, dashboard_mode
 from .models.runtime_data import RuntimeData, SmappeeSiteRuntime
 from .models.state import ConnectorState
 
@@ -370,7 +370,26 @@ async def _async_call_connector_client(
 
 
 async def handle_start_charging(call: ServiceCall) -> None:
-    await async_handle_connector_service(call.hass, call, "start_charging")
+    connector_id = call.data.get("connector_id")
+    rt, sid = _resolve_sid(call.hass, call)
+    _raise_if_ambiguous_service_location(rt, sid)
+    client = get_connector_client(rt, sid, connector_id)
+    if not client:
+        raise _service_validation_error(
+            f"No matching connector client (config_entry_id={call.data.get('config_entry_id')}, sid={call.data.get('service_location_id')}, connector_id={connector_id})",
+            "no_connector_client",
+            config_entry_id=call.data.get("config_entry_id"),
+            service_location_id=call.data.get("service_location_id"),
+            connector_id=connector_id,
+        )
+
+    percentage = connector_percentage_setpoint(_get_connector_state(rt, client))
+    await _async_call_connector_client(
+        call.hass,
+        client,
+        "start_charging",
+        {"percentage": percentage},
+    )
 
 
 async def handle_pause_charging(call: ServiceCall) -> None:

--- a/docs/HA_integration.md
+++ b/docs/HA_integration.md
@@ -62,11 +62,16 @@ Use the `max_charging_speed` number entity or `smappee_ev.set_current` to contro
 
 ### `smappee_ev.start_charging`
 
-Starts a charging session for the selected connector.
+Starts a charging session for the selected connector at the current limit that is
+already configured, so starting a session no longer raises the connector to its
+maximum current.
 
-Use `smappee_ev.set_current` or the `max_charging_speed` number entity to set the charging current separately.
+Use `smappee_ev.set_current` or the `max_charging_speed` number entity to change the
+charging current.
 
-The MQTT topic observation for starting charging is: `startcharging = {"percentageLimit":100}`.
+The MQTT topic observation for starting charging is: `startcharging = {"percentageLimit":<limit>}`,
+where `<limit>` is the connector's active setpoint as a percentage of its
+minimum-maximum current range. When no setpoint is known yet, 100 is used.
 
 ### `smappee_ev.resume_charging`
 

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -199,19 +199,22 @@ async def test_button_press_start_charging(mock_coordinator):
 
     await button.async_press()
 
-    api_client.start_charging.assert_awaited_once_with()
+    api_client.start_charging.assert_awaited_once_with(50)
     assert connector.selected_current_limit == 10
     assert connector.selected_percentage_limit == 50
     mock_coordinator.async_set_updated_data.assert_not_called()
     mock_coordinator.async_schedule_dashboard_refresh.assert_called_once()
 
 
-async def test_button_press_start_charging_ignores_restored_slider_limit(mock_coordinator):
-    """Test pressing the start charging button ignores restored slider current."""
+async def test_button_press_start_charging_derives_percentage_from_slider_limit(
+    mock_coordinator,
+):
+    """Test the start button derives the percentage when only Ampere is known."""
     api_client = MagicMock()
     api_client.start_charging = AsyncMock()
     connector = mock_coordinator.data.connectors["conn1"]
     connector.selected_current_limit = 16.5
+    connector.selected_percentage_limit = None
 
     button = SmappeeActionButton(
         coordinator=mock_coordinator,
@@ -225,7 +228,35 @@ async def test_button_press_start_charging_ignores_restored_slider_limit(mock_co
 
     await button.async_press()
 
-    api_client.start_charging.assert_awaited_once_with()
+    # 16.5 A over the 6-32 A range is 40%.
+    api_client.start_charging.assert_awaited_once_with(40)
+
+
+async def test_button_press_start_charging_keeps_a_low_current_setpoint(mock_coordinator):
+    """Regression: starting must not raise the connector to its maximum current.
+
+    Pressing start used to send percentageLimit=100, which the device echoed
+    back over MQTT and the coordinator turned into the connector maximum.
+    """
+    api_client = MagicMock()
+    api_client.start_charging = AsyncMock()
+    connector = mock_coordinator.data.connectors["conn1"]
+    connector.selected_current_limit = 6.0
+    connector.selected_percentage_limit = 0
+
+    button = SmappeeActionButton(
+        coordinator=mock_coordinator,
+        api_client=api_client,
+        sid=1,
+        station_uuid="station1",
+        connector_uuid="conn1",
+        name="Start Charging",
+        action="start_charging",
+    )
+
+    await button.async_press()
+
+    api_client.start_charging.assert_awaited_once_with(0)
 
 
 async def test_button_press_start_charging_no_connector(mock_coordinator):
@@ -245,7 +276,7 @@ async def test_button_press_start_charging_no_connector(mock_coordinator):
 
     await button.async_press()
 
-    api_client.start_charging.assert_awaited_once_with()
+    api_client.start_charging.assert_awaited_once_with(None)
 
 
 async def test_button_press_start_charging_no_coordinator_data(mock_coordinator):
@@ -268,7 +299,7 @@ async def test_button_press_start_charging_no_coordinator_data(mock_coordinator)
 
     await button.async_press()
 
-    api_client.start_charging.assert_awaited_once_with()
+    api_client.start_charging.assert_awaited_once_with(None)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -1226,3 +1226,65 @@ async def test_session_tracking_shutdown_cancels_pending_scheduled_refreshes(has
     assert all(unsub.called for unsub in unsubs)
     active_loop_unsub.assert_called_once()
     coord.connector_clients["conn-1"].async_get_recent_sessions.assert_not_awaited()
+
+
+def test_rest_merge_repairs_a_stale_mqtt_derived_current_limit():
+    """A REST poll must be able to correct the Ampere setpoint it derives."""
+    prev_connector = ConnectorState(
+        connector_number=1,
+        session_state="Charging",
+        selected_current_limit=32.0,
+        selected_percentage_limit=100,
+        optimization_strategy="NONE",
+        min_current=6,
+        max_current=32,
+    )
+    rest_connector = ConnectorState(
+        connector_number=1,
+        session_state="Charging",
+        selected_percentage_limit=0,
+        min_current=6,
+        max_current=32,
+        api_available=True,
+    )
+
+    merged = SmappeeStationCoordinator._merge_connector_rest_state(prev_connector, rest_connector)
+
+    assert merged.selected_current_limit == 6.0
+    assert merged.selected_percentage_limit == 0
+
+
+def test_rest_merge_keeps_the_current_limit_under_an_optimization_strategy():
+    """In SMART/SOLAR the percentage is optimizer-driven, not the user setpoint."""
+    prev_connector = ConnectorState(
+        connector_number=1,
+        selected_current_limit=16.0,
+        optimization_strategy="EXCESS_ONLY",
+        min_current=6,
+        max_current=32,
+    )
+    rest_connector = ConnectorState(
+        connector_number=1,
+        selected_percentage_limit=100,
+        min_current=6,
+        max_current=32,
+    )
+
+    merged = SmappeeStationCoordinator._merge_connector_rest_state(prev_connector, rest_connector)
+
+    assert merged.selected_current_limit == 16.0
+
+
+def test_rest_merge_keeps_the_current_limit_without_a_percentage():
+    prev_connector = ConnectorState(
+        connector_number=1,
+        selected_current_limit=16.0,
+        optimization_strategy="NONE",
+        min_current=6,
+        max_current=32,
+    )
+    rest_connector = ConnectorState(connector_number=1, min_current=6, max_current=32)
+
+    merged = SmappeeStationCoordinator._merge_connector_rest_state(prev_connector, rest_connector)
+
+    assert merged.selected_current_limit == 16.0

--- a/tests/test_dashboard_client.py
+++ b/tests/test_dashboard_client.py
@@ -272,6 +272,25 @@ async def test_dashboard_start_charging_action_payload():
 
 
 @pytest.mark.asyncio
+async def test_dashboard_start_charging_sends_requested_percentage():
+    """startCharging must carry the caller's limit, not a hardcoded 100%."""
+    client = SmappeeDashboardClient(
+        username=None,
+        password=None,
+        refresh_token=None,
+        session=MagicMock(),
+        token_update_callback=MagicMock(),
+    )
+    client._request = AsyncMock(return_value=True)
+
+    assert await client.async_start_charging(236259, "device-1", 0) is True
+
+    payload = client._request.await_args.kwargs["json"]
+    assert payload[0]["values"] == [{"Integer": 0}]
+    assert payload[0]["spec"]["name"] == "percentageLimit"
+
+
+@pytest.mark.asyncio
 async def test_dashboard_percentage_limit_action_payload_and_false_result():
     client = _client()
     client._request = AsyncMock(side_effect=[True, None])

--- a/tests/test_device_handle.py
+++ b/tests/test_device_handle.py
@@ -32,8 +32,12 @@ class RecordingDashboard:
     ) -> bool:
         return await self._record("async_set_charging_mode", service_location_id, device_id, mode)
 
-    async def async_start_charging(self, service_location_id: int, device_id: str) -> bool:
-        return await self._record("async_start_charging", service_location_id, device_id)
+    async def async_start_charging(
+        self, service_location_id: int, device_id: str, percentage: int = 100
+    ) -> bool:
+        return await self._record(
+            "async_start_charging", service_location_id, device_id, percentage
+        )
 
     async def async_pause_charging(self, service_location_id: int, device_id: str) -> bool:
         return await self._record("async_pause_charging", service_location_id, device_id)
@@ -411,7 +415,32 @@ async def test_start_charging_sends_start_action():
 
     await client.start_charging()
 
-    assert dashboard.calls == [("async_start_charging", (100, "DASHBOARD_DEVICE"))]
+    assert dashboard.calls == [("async_start_charging", (100, "DASHBOARD_DEVICE", 100))]
+
+
+@pytest.mark.asyncio
+async def test_start_charging_keeps_the_configured_percentage():
+    """Starting must not raise the connector to its maximum current."""
+    dashboard = RecordingDashboard()
+    client = make_client(dashboard=dashboard)
+
+    await client.start_charging(0)
+
+    assert dashboard.calls == [("async_start_charging", (100, "DASHBOARD_DEVICE", 0))]
+
+
+@pytest.mark.parametrize(
+    ("percentage", "expected"),
+    [(-5, 0), (0, 0), (42, 42), (100, 100), (140, 100)],
+)
+@pytest.mark.asyncio
+async def test_start_charging_clamps_percentage(percentage, expected):
+    dashboard = RecordingDashboard()
+    client = make_client(dashboard=dashboard)
+
+    await client.start_charging(percentage)
+
+    assert dashboard.calls == [("async_start_charging", (100, "DASHBOARD_DEVICE", expected))]
 
 
 @pytest.mark.asyncio

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
 import custom_components.smappee_ev.helpers as helpers
+from custom_components.smappee_ev.models.state import ConnectorState
 
 
 def test_dashboard_property_value_supports_value_and_values_payloads():
@@ -48,3 +49,52 @@ def test_safe_sum_invalid():
     assert helpers.safe_sum([1, "x"]) is None
     # Not a list/tuple -> None
     assert helpers.safe_sum({"a": 1}) is None  # type: ignore[arg-type]
+
+
+def test_percentage_to_current_maps_across_the_connector_range():
+    assert helpers.percentage_to_current(0, 6, 32) == 6.0
+    assert helpers.percentage_to_current(50, 6, 32) == 19.0
+    assert helpers.percentage_to_current(100, 6, 32) == 32.0
+
+
+def test_percentage_to_current_survives_a_collapsed_range():
+    # A connector reporting max <= min must not divide by zero.
+    assert helpers.percentage_to_current(100, 6, 6) == 7.0
+    assert helpers.percentage_to_current(100, 6, 0) == 7.0
+
+
+def test_current_to_percentage_is_the_inverse_and_clamps():
+    assert helpers.current_to_percentage(6, 6, 32) == 0
+    assert helpers.current_to_percentage(19, 6, 32) == 50
+    assert helpers.current_to_percentage(32, 6, 32) == 100
+    assert helpers.current_to_percentage(48, 6, 32) == 100
+    assert helpers.current_to_percentage(1, 6, 32) == 0
+
+
+def test_connector_percentage_setpoint_prefers_the_reported_percentage():
+    state = ConnectorState(
+        connector_number=1,
+        min_current=6,
+        max_current=32,
+        selected_current_limit=32.0,
+        selected_percentage_limit=0,
+    )
+
+    assert helpers.connector_percentage_setpoint(state) == 0
+
+
+def test_connector_percentage_setpoint_falls_back_to_the_ampere_setpoint():
+    state = ConnectorState(
+        connector_number=1,
+        min_current=6,
+        max_current=32,
+        selected_current_limit=19.0,
+        selected_percentage_limit=None,
+    )
+
+    assert helpers.connector_percentage_setpoint(state) == 50
+
+
+def test_connector_percentage_setpoint_is_none_when_unknown():
+    assert helpers.connector_percentage_setpoint(None) is None
+    assert helpers.connector_percentage_setpoint(ConnectorState(connector_number=1)) is None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -422,7 +422,32 @@ class TestServiceHandlers:
 
         await services.handle_start_charging(call)
 
-        mock_api_client.start_charging.assert_called_once_with()
+        mock_api_client.start_charging.assert_called_once_with(percentage=None)
+
+    @pytest.mark.asyncio
+    async def test_handle_start_charging_forwards_the_connector_setpoint(self, mock_hass):
+        """The service must start at the configured limit, not the connector maximum."""
+        connector_client = make_connector_client(
+            service_location_id=44444,
+            connector_number=1,
+            smart_device_uuid="connector-setpoint",
+        )
+        runtime = make_runtime_for_connector(44444, connector_client)
+        coordinator = runtime.sites[44444].stations["station_44444"].station_coordinator
+        conn_state = coordinator.data.connectors["connector-setpoint"]
+        conn_state.selected_percentage_limit = 0
+        conn_state.selected_current_limit = 6.0
+        configure_loaded_entries(mock_hass, [make_loaded_config_entry("entry", runtime)])
+        call = ServiceCall(
+            domain="smappee_ev",
+            service="start_charging",
+            data={"service_location_id": 44444, "connector_id": 1},
+            hass=mock_hass,
+        )
+
+        await services.handle_start_charging(call)
+
+        connector_client.start_charging.assert_awaited_once_with(percentage=0)
 
     @pytest.mark.asyncio
     async def test_handle_pause_charging_success(
@@ -657,7 +682,7 @@ class TestServiceHandlers:
 
         await services.handle_start_charging(call)
 
-        site_a_client.start_charging.assert_awaited_once_with()
+        site_a_client.start_charging.assert_awaited_once_with(percentage=None)
         site_b_client.start_charging.assert_not_called()
 
     @pytest.mark.asyncio
@@ -690,7 +715,7 @@ class TestServiceHandlers:
         await services.handle_start_charging(call)
 
         site_a_client.start_charging.assert_not_called()
-        site_b_client.start_charging.assert_awaited_once_with()
+        site_b_client.start_charging.assert_awaited_once_with(percentage=None)
 
     @pytest.mark.asyncio
     async def test_connector_service_resolves_dataclass_runtime_station(self, mock_hass):


### PR DESCRIPTION
## Problem

Pressing the start-charging button, or calling `smappee_ev.start_charging`, resets `number.<device>_current_<n>` to the connector maximum (32 A) and discards the configured setpoint.

## Root cause

`async_start_charging` sent a hardcoded `percentageLimit: 100`:

```python
"values": [{"Integer": 100}],
```

That is the same device field `async_set_percentage_limit` writes for the current slider. Every start therefore overwrote the user's setpoint with the top of the connector range.

The device stores the value. On the next `chargingstate` MQTT message the coordinator maps it back to Ampere:

```python
rng = max(int(conn.max_current) - int(conn.min_current), 1)
cur = round((pct / 100.0) * rng + float(conn.min_current), 1)
```

With `percentageLimit=100` and a 6-32 A range that is 32.0 A.

The value could not recover on its own. `_fetch_connector_state` declared a `selected_current` local that was never assigned, so REST always merged `selected_current_limit=None` and `_merge_connector_rest_state` fell back to the stale previous value indefinitely.

## Evidence

Measured on a live EV Wall, single connector, 6-32 A range, standard mode:

- Start pressed while the session was suspended: the slider jumped to 32.0 A within ~0.7 s, on the same `chargingstate` message that carried the session transition (the two entity updates land 2 ms apart).
- Start pressed while the session was already charging: no visible change at the time, but the value was stored. It surfaced 2 min 28 s later on the next state transition (a pause), moving the slider to 32.0 A 0.15 s after the pause command. So the write persists on the device; the visible jump only waits for the next `chargingstate` message.
- A session resume that involved no start command produced no jump.
- Delivered current stayed at ~5.9 A per phase through every window in which 100% was stored (30 consecutive samples, ~4.0 kW on 3 phases). The stored limit did not translate into actual charging current on this firmware, although a vehicle-side limit cannot be excluded.

The third and fourth points matter for triage: the jump is caused by the start command, not by the state transition it appears next to.

## Fix

- `async_start_charging` takes a `percentage` argument (default 100, so the signature stays backward compatible) and shares the payload builder with `async_set_percentage_limit`.
- `start_charging` clamps to 0-100. The button and the service pass the connector's active setpoint, preferring the percentage the API reported and falling back to deriving it from the Ampere setpoint. When neither is known it falls back to 100, the previous behaviour.
- `_merge_connector_rest_state` now derives `selected_current_limit` from the polled `percentageLimit`, behind the same optimization-strategy gate the MQTT path already uses, so a poll can correct a stale setpoint while SMART and SOLAR keep their optimizer-driven behaviour.

## Tests

`670 passed`, coverage 95.14% (gate 95%). `mypy --config-file=mypy.ini` clean. Ruff and codespell clean.

New regression tests were verified to fail against the pre-fix source, including one that reproduces the reported symptom directly: `selected_current_limit=32.0` sitting alongside `selected_percentage_limit=0`.

## Notes

- Behaviour change worth calling out in the changelog: starting a session no longer implies full speed. Anyone relying on start to un-throttle a connector will see a difference.
- **#290** is likely the same root cause. Jumps attributed to `switch.turn_on` are consistent with an earlier `startCharging` surfacing on the next `chargingstate` message: `switch.turn_on` itself only sends `setChargingMode`, which carries no percentage field. Testing `turn_on` from both an active and a paused session produced no jump when no start command had preceded it. Not closing that issue here.
